### PR TITLE
Update to 7.14.0

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "FileGator"
 description.en = "Multi-User File Manager"
 description.fr = "Gestionnaire de fichiers multi-utilisateurs"
 
-version = "7.13.5~ynh3"
+version = "7.14.0~ynh1"
 
 maintainers = ["eric_G"]
 
@@ -57,7 +57,7 @@ ram.runtime = "50M"
 
     [resources.sources.main]
     url = "https://github.com/filegator/static/raw/master/builds/filegator_latest.zip"
-    sha256 = "c630cba23d0ffaf97a021b682b86f6596f0fda0e7ceb377992792848a6581951"
+    sha256 = "a52a85ab7feb9b10d3db6ef2a358dd71f23d758c88c515ea5b32924fd3127862"
 
     [resources.system_user]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -56,7 +56,7 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/filegator/static/raw/master/builds/filegator_latest.zip"
+    url = "https://github.com/filegator/static/raw/master/builds/filegator_v7.14.0.zip"
     sha256 = "a52a85ab7feb9b10d3db6ef2a358dd71f23d758c88c515ea5b32924fd3127862"
 
     [resources.system_user]


### PR DESCRIPTION
This updates the package to the latest version, 7.14.0.

It also changes the `url` in the manifest, so that it gets the numbered file instead of `filegator_latest.zip`. Like this when the Yunohost package lags behind, it can still be installed (otherwise the checksum fails).

I tested on my server, it works smoothly.

Should fix #13.